### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/chatbot_backend/chatbot/views.py
+++ b/chatbot_backend/chatbot/views.py
@@ -39,7 +39,7 @@ class UserRegistrationView(APIView):
                 return Response(status=status.HTTP_201_CREATED)
             except Exception as e:
                 logger.error(f"Error during user registration: {str(e)}")
-                return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({'error': 'An error occurred during registration. Please try again later.'}, status=status.HTTP_400_BAD_REQUEST)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -172,7 +172,7 @@ class ChatHistoryView(APIView):
         except Exception as e:
             logger.error(f"Chat history error: {str(e)}")
             return Response(
-                {'error': 'Failed to save chat history'},
+                {'error': 'An error occurred while saving chat history. Please try again later.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 

--- a/chatbot_backend/chatbot/views.py
+++ b/chatbot_backend/chatbot/views.py
@@ -39,9 +39,12 @@ class UserRegistrationView(APIView):
                 return Response(status=status.HTTP_201_CREATED)
             except Exception as e:
                 logger.error(f"Error during user registration: {str(e)}")
-                return Response({'error': 'An error occurred during registration. Please try again later.'}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+                return Response(
+                    {'error': 'An error occurred during registration. Please try again later.'},
+                    status=status.HTTP_400_BAD_REQUEST
+                        )
+            else:
+                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class UserLoginView(APIView):
     """Handle user login and token authentication"""


### PR DESCRIPTION
Potential fix for [https://github.com/LewisJassy/chatbot/security/code-scanning/1](https://github.com/LewisJassy/chatbot/security/code-scanning/1)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the response in the exception handling block to return a generic error message while keeping the logging of the detailed error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
